### PR TITLE
it actully expects segments when do comparing

### DIFF
--- a/torch/cuda/_memory_viz.py
+++ b/torch/cuda/_memory_viz.py
@@ -135,6 +135,11 @@ def memory(snapshot, format_flamegraph=format_flamegraph):
     return format_flamegraph(f.getvalue())
 
 def compare(before, after, format_flamegraph=format_flamegraph):
+    assert 'segments' in before
+    before = before['segments']
+    assert 'segments' in after
+    after = after['segments']
+
     def _seg_key(seg):
         return (seg['address'], seg['total_size'])
 


### PR DESCRIPTION
we know snapshot contains a segments attribute from [here](https://pytorch.org/docs/stable/torch_cuda_memory.html#torch.cuda.memory._snapshot).

and also we know it expect seg to be a `Segment` from [here](https://github.com/pytorch/pytorch/blob/ed94725b8c5d70b31659d10775c011a23cbcb464/torch/cuda/_memory_viz.py#L139)